### PR TITLE
Remove dependency on all of lodash for one tiny each()

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "test": "node_modules/.bin/mocha ./test.js"
   },
   "dependencies": {
-    "bignumber.js": "~1.4.1",
-    "lodash": "~2.4.1"
+    "bignumber.js": "~1.4.1"
   },
   "devDependencies": {
     "chai": "~1.10.0",

--- a/vend-number.js
+++ b/vend-number.js
@@ -6,7 +6,6 @@
     'use strict';
 
     var BigNumber = require('bignumber.js'),
-        _  = require('lodash'),
         VendNumber;
 
     VendNumber = {
@@ -154,7 +153,7 @@
                 returnValue = new VendNumber.VendNumber(returnValue);
             });
 
-            _.each(values, function (value) {
+            values.forEach(function (value) {
                 value = parseFloat(value);
 
                 _ifValid(value, function () {


### PR DESCRIPTION
Now that downstream products are pulling in bits of lodash 3 etc this results in a whole extra copy of lodash in our browserify bundles. It is overkill to pull in for something we can do natively anyway.