### PR TITLE
Bump bignumber.js version, primarily to reduce browserified size

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bignumber.js": "~2.0.7"
+    "bignumber.js": "~2.3.0"
   },
   "devDependencies": {
     "babel": "~5.8.23",


### PR DESCRIPTION
![shrink](https://media.giphy.com/media/3o6MbnF8idBhsorNug/giphy.gif)

bignumber.js 2.0.x will pull in the full node.js `crypto` module when browserified. As of 2.1 this has been made optional in a browserify environment, allowing us to significantly reduce our bundle size as we don't use the cryptographic random number generation feature.