### PR TITLE
Rounding Modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,22 @@ add(3, multiply(4, 5)) // returns 23
 
 ### Rounding and formatting
 
-Round a value to a specified number of decimal points.
+Round a value to a specified number of decimal points. The default rounding mode is `ROUND_HALF_UP`, the 'Round Half
+Away From Zero' tie-breaking rule.
 
 ```js
 VendNumber.round(5.545333, 2) // "5.55"
+```
+
+#### Rounding modes
+
+You can specify any of the [Big Number rounding modes](http://mikemcl.github.io/bignumber.js/#round-up) to the `round`
+function. These are available via `VendNumber.ROUNDING_METHODS`.
+
+```js
+import VendNumber, { ROUNDING_METHODS } from 'vend-number'
+
+VendNumber.round(5.545333, 2, ROUNDING_METHODS.ROUND_DOWN) // "5.54"
 ```
 
 ### isFinite
@@ -114,7 +126,7 @@ VendNumber.isFinite('-123.456') // true
 
 Calculates the sum of all items in a collection based on a property name.
 
-Accepts the following parameters: 
+Accepts the following parameters:
 
   - `Array` an array of items to loop through.
   - `String` a property name to sum by.

--- a/dist/vend-number.js
+++ b/dist/vend-number.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, '__esModule', {
   value: true
 });
 
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+var _get = function get(_x3, _x4, _x5) { var _again = true; _function: while (_again) { var object = _x3, property = _x4, receiver = _x5; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x3 = parent; _x4 = property; _x5 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
@@ -82,16 +82,20 @@ VendNumber.vn = function (value) {
  * @param [decimalPoints=2]
  *        The number of decimal points to round the passed value to, or two.
  *
+ * @param [roundingMode=BigNumber.ROUND_HALF_UP]
+ *        The required rounding mode. Defaults to ROUND_HALF_UP (4).
+ *        See https://mikemcl.github.io/bignumber.js/#round-up for other rounding modes
+ *
  * @return {String} The rounded value.
  */
-VendNumber.round = function (value, decimalPoints) {
+VendNumber.round = function (value) {
+  var decimalPoints = arguments.length <= 1 || arguments[1] === undefined ? 2 : arguments[1];
+  var roundingMode = arguments.length <= 2 || arguments[2] === undefined ? _bignumberJs2['default'].ROUND_HALF_UP : arguments[2];
+
   // Convert to VendNumber if not already.
   value = value instanceof _bignumberJs2['default'] ? value : new VendNumber(value);
 
-  // 2dp by default.
-  decimalPoints = typeof decimalPoints === 'number' ? decimalPoints : 2;
-
-  return value.toFixed(decimalPoints);
+  return value.toFixed(decimalPoints, roundingMode);
 };
 
 /**

--- a/dist/vend-number.js
+++ b/dist/vend-number.js
@@ -19,6 +19,18 @@ var _bignumberJs = require('bignumber.js');
 
 var _bignumberJs2 = _interopRequireDefault(_bignumberJs);
 
+var ROUNDING_MODES = {
+  ROUND_UP: _bignumberJs2['default'].ROUND_UP,
+  ROUND_DOWN: _bignumberJs2['default'].ROUND_DOWN,
+  ROUND_CEIL: _bignumberJs2['default'].ROUND_CEIL,
+  ROUND_FLOOR: _bignumberJs2['default'].ROUND_FLOOR,
+  ROUND_HALF_UP: _bignumberJs2['default'].ROUND_HALF_UP,
+  ROUND_HALF_DOWN: _bignumberJs2['default'].ROUND_HALF_DOWN,
+  ROUND_HALF_EVEN: _bignumberJs2['default'].ROUND_HALF_EVEN,
+  ROUND_HALF_CEIL: _bignumberJs2['default'].ROUND_HALF_CEIL,
+  ROUND_HALF_FLOOR: _bignumberJs2['default'].ROUND_HALF_FLOOR
+};
+
 var VendNumber = (function (_BigNumber) {
   _inherits(VendNumber, _BigNumber);
 
@@ -52,20 +64,29 @@ var VendNumber = (function (_BigNumber) {
   }
 
   /**
-   * Quick convenience function for creating VendNumber instances. E.g. `vn(123)` is the same as `new VendNumber(123)`.
+   * Available rounding modes.
    *
-   * @method vn
-   * @static
-   *
-   * @param value {Number | String}
-   *        The value to make a VendNumber
-   *
-   * @return {VendNumber} A VendNumber instance for the given value
+   * @property ROUNDING_MODES
+   * @type {Object}
+   * @readOnly
    */
   return VendNumber;
 })(_bignumberJs2['default']);
 
 exports['default'] = VendNumber;
+VendNumber.ROUNDING_MODES = ROUNDING_MODES;
+
+/**
+ * Quick convenience function for creating VendNumber instances. E.g. `vn(123)` is the same as `new VendNumber(123)`.
+ *
+ * @method vn
+ * @static
+ *
+ * @param value {Number | String}
+ *        The value to make a VendNumber
+ *
+ * @return {VendNumber} A VendNumber instance for the given value
+ */
 VendNumber.vn = function (value) {
   return new VendNumber(value);
 };
@@ -90,7 +111,7 @@ VendNumber.vn = function (value) {
  */
 VendNumber.round = function (value) {
   var decimalPoints = arguments.length <= 1 || arguments[1] === undefined ? 2 : arguments[1];
-  var roundingMode = arguments.length <= 2 || arguments[2] === undefined ? _bignumberJs2['default'].ROUND_HALF_UP : arguments[2];
+  var roundingMode = arguments.length <= 2 || arguments[2] === undefined ? ROUNDING_MODES.ROUND_HALF_UP : arguments[2];
 
   // Convert to VendNumber if not already.
   value = value instanceof _bignumberJs2['default'] ? value : new VendNumber(value);

--- a/src/vend-number.js
+++ b/src/vend-number.js
@@ -5,6 +5,18 @@
 
 import BigNumber from 'bignumber.js'
 
+const ROUNDING_MODES = {
+  ROUND_UP: BigNumber.ROUND_UP,
+  ROUND_DOWN: BigNumber.ROUND_DOWN,
+  ROUND_CEIL: BigNumber.ROUND_CEIL,
+  ROUND_FLOOR: BigNumber.ROUND_FLOOR,
+  ROUND_HALF_UP: BigNumber.ROUND_HALF_UP,
+  ROUND_HALF_DOWN: BigNumber.ROUND_HALF_DOWN,
+  ROUND_HALF_EVEN: BigNumber.ROUND_HALF_EVEN,
+  ROUND_HALF_CEIL: BigNumber.ROUND_HALF_CEIL,
+  ROUND_HALF_FLOOR: BigNumber.ROUND_HALF_FLOOR
+}
+
 export default class VendNumber extends BigNumber {
   /**
    * Vend extension of BigNumber.
@@ -32,6 +44,15 @@ export default class VendNumber extends BigNumber {
     super(value ? value.toString() : 0)
   }
 }
+
+/**
+ * Available rounding modes.
+ *
+ * @property ROUNDING_MODES
+ * @type {Object}
+ * @readOnly
+ */
+VendNumber.ROUNDING_MODES = ROUNDING_MODES
 
 /**
  * Quick convenience function for creating VendNumber instances. E.g. `vn(123)` is the same as `new VendNumber(123)`.
@@ -66,7 +87,7 @@ VendNumber.vn = function (value) {
  *
  * @return {String} The rounded value.
  */
-VendNumber.round = function (value, decimalPoints = 2, roundingMode = BigNumber.ROUND_HALF_UP) {
+VendNumber.round = function (value, decimalPoints = 2, roundingMode = ROUNDING_MODES.ROUND_HALF_UP) {
   // Convert to VendNumber if not already.
   value = (value instanceof BigNumber) ? value : new VendNumber(value)
 

--- a/src/vend-number.js
+++ b/src/vend-number.js
@@ -60,16 +60,17 @@ VendNumber.vn = function (value) {
  * @param [decimalPoints=2]
  *        The number of decimal points to round the passed value to, or two.
  *
+ * @param [roundingMode=BigNumber.ROUND_HALF_UP]
+ *        The required rounding mode. Defaults to ROUND_HALF_UP (4).
+ *        See https://mikemcl.github.io/bignumber.js/#round-up for other rounding modes
+ *
  * @return {String} The rounded value.
  */
-VendNumber.round = function (value, decimalPoints) {
+VendNumber.round = function (value, decimalPoints = 2, roundingMode = BigNumber.ROUND_HALF_UP) {
   // Convert to VendNumber if not already.
   value = (value instanceof BigNumber) ? value : new VendNumber(value)
 
-  // 2dp by default.
-  decimalPoints = (typeof decimalPoints === 'number') ? decimalPoints : 2
-
-  return value.toFixed(decimalPoints)
+  return value.toFixed(decimalPoints, roundingMode)
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 /*global require, describe, it */
 'use strict'
 
-import VendNumber, { vn, round, add, subtract, multiply, divide, isFinite, sumBy } from '../'
+import VendNumber, { vn, round, add, subtract, multiply, divide, isFinite, sumBy, ROUNDING_MODES } from '../'
 import BigNumber from 'bignumber.js'
 import { expect } from 'chai'
 
@@ -60,7 +60,7 @@ describe('VendNumber', () => {
 
   describe('#round', () => {
     /*
-     * Our round function uses the 'Round Half Away From Zero' tie-breaking rule.
+     * Our default round function uses ROUND_HALF_UP the 'Round Half Away From Zero' tie-breaking rule.
      *
      * For example (When rounding to 1 decimal place):
      *
@@ -170,6 +170,69 @@ describe('VendNumber', () => {
         expect(round(-1, 3)).to.equal('-1.000')
         expect(round(-1, 4)).to.equal('-1.0000')
         expect(round(-1, 5)).to.equal('-1.00000')
+      })
+    })
+
+    describe('rounding modes', () => {
+      describe('ROUND_UP', () => {
+        it('should round away from zero', () => {
+          expect(round(0.9, 0, ROUNDING_MODES.ROUND_UP)).to.equal('1')
+          expect(round(0.03169086, 3, ROUNDING_MODES.ROUND_UP)).to.equal('0.032')
+        })
+      })
+
+      describe('ROUND_DOWN', () => {
+        it('should round towards zero', () => {
+          expect(round(0.9, 0, ROUNDING_MODES.ROUND_DOWN)).to.equal('0')
+          expect(round(0.03169086, 3, ROUNDING_MODES.ROUND_DOWN)).to.equal('0.031')
+        })
+      })
+
+      describe('ROUND_CEIL', () => {
+        it('should round towards Infinity', () => {
+          expect(round(0.9028782, 4, ROUNDING_MODES.ROUND_CEIL)).to.equal('0.9029')
+          expect(round(-0.9028782, 4, ROUNDING_MODES.ROUND_CEIL)).to.equal('-0.9028')
+        })
+      })
+
+      describe('ROUND_FLOOR', () => {
+        it('should round towards -Infinity', () => {
+          expect(round(0.9028782, 4, ROUNDING_MODES.ROUND_FLOOR)).to.equal('0.9028')
+          expect(round(-0.9028782, 4, ROUNDING_MODES.ROUND_FLOOR)).to.equal('-0.9029')
+        })
+      })
+
+      describe('ROUND_HALF_UP', () => {
+        it('should round towards nearest neighbour and if equidistant, round away from zero', () => {
+          expect(round(5.5, 0, ROUNDING_MODES.ROUND_HALF_UP)).to.equal('6')
+          expect(round(5.55, 1, ROUNDING_MODES.ROUND_HALF_UP)).to.equal('5.6')
+        })
+      })
+
+      describe('ROUND_HALF_DOWN', () => {
+        it('should round towards nearest neighbour and if equidistant, round towards zero', () => {
+          expect(round(5.5, 0, ROUNDING_MODES.ROUND_HALF_DOWN)).to.equal('5')
+          expect(round(5.55, 1, ROUNDING_MODES.ROUND_HALF_DOWN)).to.equal('5.5')
+        })
+      })
+
+      describe('ROUND_HALF_EVEN', () => {
+        it('should round towards nearest neighbour and if equidistant, round towards nearest even neighbour', () => {
+          expect(round(-2.426346, 4, ROUNDING_MODES.ROUND_HALF_EVEN)).to.equal('-2.4263')
+          expect(round(0.3564473, 3, ROUNDING_MODES.ROUND_HALF_EVEN)).to.equal('0.356')
+        })
+      })
+
+      describe('ROUND_HALF_CEIL', () => {
+        it('should round towards nearest neighbour and if equidistant, round towards nearest Infinity', () => {
+          expect(round(76700.5, 0, ROUNDING_MODES.ROUND_HALF_CEIL)).to.equal('76701')
+        })
+      })
+
+      describe('ROUND_HALF_FLOOR', () => {
+        it('should round towards nearest neighbour and if equidistant, round towards nearest -Infinity', () => {
+          expect(round(76700.5, 0, ROUNDING_MODES.ROUND_HALF_FLOOR)).to.equal('76700')
+        })
       })
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -177,6 +177,7 @@ describe('VendNumber', () => {
       describe('ROUND_UP', () => {
         it('should round away from zero', () => {
           expect(round(0.9, 0, ROUNDING_MODES.ROUND_UP)).to.equal('1')
+          expect(round(-0.9, 0, ROUNDING_MODES.ROUND_UP)).to.equal('-1')
           expect(round(0.03169086, 3, ROUNDING_MODES.ROUND_UP)).to.equal('0.032')
         })
       })
@@ -184,6 +185,7 @@ describe('VendNumber', () => {
       describe('ROUND_DOWN', () => {
         it('should round towards zero', () => {
           expect(round(0.9, 0, ROUNDING_MODES.ROUND_DOWN)).to.equal('0')
+          expect(round(-0.9, 0, ROUNDING_MODES.ROUND_DOWN)).to.equal('-0')
           expect(round(0.03169086, 3, ROUNDING_MODES.ROUND_DOWN)).to.equal('0.031')
         })
       })
@@ -206,6 +208,7 @@ describe('VendNumber', () => {
         it('should round towards nearest neighbour and if equidistant, round away from zero', () => {
           expect(round(5.5, 0, ROUNDING_MODES.ROUND_HALF_UP)).to.equal('6')
           expect(round(5.55, 1, ROUNDING_MODES.ROUND_HALF_UP)).to.equal('5.6')
+          expect(round(-5.5, 0, ROUNDING_MODES.ROUND_HALF_UP)).to.equal('-6')
         })
       })
 
@@ -213,6 +216,7 @@ describe('VendNumber', () => {
         it('should round towards nearest neighbour and if equidistant, round towards zero', () => {
           expect(round(5.5, 0, ROUNDING_MODES.ROUND_HALF_DOWN)).to.equal('5')
           expect(round(5.55, 1, ROUNDING_MODES.ROUND_HALF_DOWN)).to.equal('5.5')
+          expect(round(-5.5, 0, ROUNDING_MODES.ROUND_HALF_DOWN)).to.equal('-5')
         })
       })
 


### PR DESCRIPTION
![](https://media2.giphy.com/media/7LvqJfRdN7wY0/giphy.gif)

The current `round` function uses BigNumber's default rounding mode of `ROUND_HALF_UP` and there is no way to specify a different rounding mode on a case by case basis. So:

- Allow a rounding mode to be passed to the `round` function.
- Expose available rounding modes via `VendNumber.ROUNDING_MODES`.
- Add some basic unit tests to assert different round modes (these are already [extensively tested in BigNumber](https://github.com/MikeMcl/bignumber.js/blob/master/test/round.js)).
