### PR TITLE
Bump BigNumber.js dependency to v4.0.0 (latest major version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bignumber.js": "~2.3.0"
+    "bignumber.js": "~4.0.0"
   },
   "devDependencies": {
     "babel": "~5.8.23",


### PR DESCRIPTION
![Bump](https://media2.giphy.com/media/ETZoGJjXYmThm/giphy.gif)

In response to discussion around solving Safari 10.1 issues. 
 
## Plan
- Bump our BigNumber.js version to latest major version. 
- Release Vend-Number with this dep change at `v3.0.0`
- Release a patch release that uses the fork with Safari fix (https://github.com/Ka0o0/bignumber.js)
- Eventually patch or minor bump and resume using original lib when either:
   - BigNumber.js releases a fix

   OR
   - Safari Browser fix is released 