### PR TITLE
Temporarily use forked bignumber.js dep to resolve Safari 10.1 Bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bignumber.js": "~4.0.0"
+    "bignumber.js": "git+ssh://git@github.com/Ka0o0/bignumber.js"
   },
   "devDependencies": {
     "babel": "~5.8.23",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bignumber.js": "git+ssh://git@github.com/Ka0o0/bignumber.js"
+    "bignumber.js": "https://github.com/Ka0o0/bignumber.js#623d87200964618f2e6f3ceafa5d6ab979c47753"
   },
   "devDependencies": {
     "babel": "~5.8.23",


### PR DESCRIPTION
![Sigh](https://media3.giphy.com/media/LAFShX32UwUj6/giphy.gif)

Not ideal but, workable solution to our Safari 10.1 woes. 

See upstream issue for ongoing discussion 👉  https://github.com/MikeMcl/bignumber.js/issues/120

## The Webkit Bug
This is the webkit bug that causes our woes: https://bugs.webkit.org/show_bug.cgi?id=170264

## The Fix
You can see the simple workaround here: https://github.com/MikeMcl/bignumber.js/compare/master...Ka0o0:master

## Plan

- Release a patch version `v3.0.1` that uses the forked BigNumber.js which has Safari workaround 
- Watch BigNumber.js and Safari Updates and restore back to original BigNumber.js package once issue is resolved. 