### PR TITLE
Move function to outside of the class def

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,15 @@ declare module 'vend-number' {
       ROUND_HALF_CEIL: RoundingMode,
       ROUND_HALF_FLOOR: RoundingMode
     }
+
+    static vn(value?: Stringable): VendNumber
+    static round(value?: Stringable, decimalPoints?: number, roundingMode?: RoundingMode): string
+    static add(...values: Stringable[]): number
+    static subtract(...values: Stringable[]): number
+    static multiply(...values: Stringable[]): number
+    static divide(...values: Stringable[]): number
+    static sumBy<T, K extends keyof T>(collection: T[], property: K, decimalPoints: number): string
+    static isFinite(value: number | string | BigNumber): boolean
   }
 
   export function vn(value?: Stringable): VendNumber

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,14 +56,14 @@ declare module 'vend-number' {
       ROUND_HALF_CEIL: RoundingMode,
       ROUND_HALF_FLOOR: RoundingMode
     }
-
-    static vn(value?: Stringable): VendNumber
-    static round(value?: Stringable, decimalPoints?: number, roundingMode?: RoundingMode): string
-    static add(...values: Stringable[]): number
-    static subtract(...values: Stringable[]): number
-    static multiply(...values: Stringable[]): number
-    static divide(...values: Stringable[]): number
-    static sumBy<T, K extends keyof T>(collection: T[], property: K, decimalPoints: number): string
-    static isFinite(value: number | string | BigNumber): boolean
   }
+
+  export function vn(value?: Stringable): VendNumber
+  export function round(value?: Stringable, decimalPoints?: number, roundingMode?: RoundingMode): string
+  export function add(...values: Stringable[]): number
+  export function subtract(...values: Stringable[]): number
+  export function multiply(...values: Stringable[]): number
+  export function divide(...values: Stringable[]): number
+  export function sumBy<T, K extends keyof T>(collection: T[], property: K, decimalPoints: number): string
+  export function isFinite(value: number | string | BigNumber): boolean
 }


### PR DESCRIPTION
![giphy 24](https://user-images.githubusercontent.com/8260377/43696483-4598e7d8-9992-11e8-81ba-38ab2205fff3.gif)

### Summary

In preparation of migrating the promotion modal to product-ui, need to update the the type definition to use vend number in typescript. 

The functions wasn't accessible when they were static function of VendNumber class. It works when I moved the functions outside. 