### PR TITLE
Allow isFinite to accept any

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,7 @@ declare module 'vend-number' {
     static multiply(...values: Stringable[]): number
     static divide(...values: Stringable[]): number
     static sumBy<T, K extends keyof T>(collection: T[], property: K, decimalPoints: number): string
-    static isFinite(value: null | number | string | BigNumber): boolean
+    static isFinite(value: any): boolean
   }
 
   export function vn(value?: Stringable): VendNumber
@@ -74,5 +74,5 @@ declare module 'vend-number' {
   export function multiply(...values: Stringable[]): number
   export function divide(...values: Stringable[]): number
   export function sumBy<T, K extends keyof T>(collection: T[], property: K, decimalPoints: number): string
-  export function isFinite(value: null | number | string | BigNumber): boolean
+  export function isFinite(value: any): boolean
 }


### PR DESCRIPTION
There was a small breaking type change between 4.0.0 and 4.1.0, where the latter's `isFinite` accepted `any` as the argument. This should be fine in practice, so I'm bringing back that type change.