### PR TITLE
Expose ROUNDING MODES

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,17 +57,7 @@ declare module 'vend-number' {
   export default class VendNumber extends BigNumber {
     constructor (value?: Stringable)
 
-    static readonly ROUNDING_MODES: {
-      ROUND_UP: RoundingMode,
-      ROUND_DOWN: RoundingMode,
-      ROUND_CEIL: RoundingMode,
-      ROUND_FLOOR: RoundingMode,
-      ROUND_HALF_UP: RoundingMode,
-      ROUND_HALF_DOWN: RoundingMode,
-      ROUND_HALF_EVEN: RoundingMode,
-      ROUND_HALF_CEIL: RoundingMode,
-      ROUND_HALF_FLOOR: RoundingMode
-    }
+    static readonly ROUNDING_MODES: typeof ROUNDING_MODES
 
     static vn(value?: Stringable): VendNumber
     static round(value?: Stringable, decimalPoints?: number, roundingMode?: RoundingMode): string

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,18 @@ declare module 'vend-number' {
     EUCLID = 9
   }
 
+  export const ROUNDING_MODES = {
+    ROUND_UP: RoundingMode.ROUND_UP,
+    ROUND_DOWN: RoundingMode.ROUND_DOWN,
+    ROUND_CEIL: RoundingMode.ROUND_CEIL,
+    ROUND_FLOOR: RoundingMode.ROUND_FLOOR,
+    ROUND_HALF_UP: RoundingMode.ROUND_HALF_UP,
+    ROUND_HALF_DOWN: RoundingMode.ROUND_HALF_DOWN,
+    ROUND_HALF_EVEN: RoundingMode.ROUND_HALF_EVEN,
+    ROUND_HALF_CEIL: RoundingMode.ROUND_HALF_CEIL,
+    ROUND_HALF_FLOOR: RoundingMode.ROUND_HALF_FLOOR,
+  } as const
+
   export default class VendNumber extends BigNumber {
     constructor (value?: Stringable)
 


### PR DESCRIPTION
PR adds `ROUNDING_MODES` to the definition file (since we're [exporting ROUNDING_MODES](https://github.com/vend/vend-number/blob/master/src/vend-number.js#L3-L13)).


